### PR TITLE
fix for issue #1992: Confusing attribute names in PairwiseAligner (#2…

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1179,7 +1179,7 @@ class PairwiseAlignment(object):
         aligned to each other. In particular, this may occur if alignments
         differ from each other in terms of their gap placement only:
 
-        >>> aligner.mismatch = -10
+        >>> aligner.mismatch_score = -10
         >>> alignments = aligner.align("AAACAAA", "AAAGAAA")
         >>> len(alignments)
         2
@@ -1345,8 +1345,8 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     1 point is deducted for each non-identical character.
 
     >>> aligner.mode = 'global'
-    >>> aligner.match = 2
-    >>> aligner.mismatch = -1
+    >>> aligner.match_score = 2
+    >>> aligner.mismatch_score = -1
     >>> for alignment in aligner.align("ACCGT", "ACG"):
     ...     print("Score = %.1f:" % alignment.score)
     ...     print(alignment)
@@ -1404,6 +1404,13 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     <BLANKLINE>
 
     """
+
+    def __setattr__(self, key, value):
+        if key not in dir(_aligners.PairwiseAligner):
+            # To prevent confusion, don't allow users to create new attributes
+            message = "'PairwiseAligner' object has no attribute '%s'" % key
+            raise AttributeError(message)
+        _aligners.PairwiseAligner.__setattr__(self, key, value)
 
     def align(self, seqA, seqB):
         """Return the alignments of two sequences using PairwiseAligner."""

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -1824,79 +1824,79 @@ Aligner_str(Aligner* self)
     n = sprintf(text, "Pairwise sequence aligner with parameters\n");
     p += n;
     if (self->letters) {
-        n = sprintf(p, "  match/mismatch score: <substitution matrix>\n");
+        n = sprintf(p, "  match/mismatch_score: <substitution matrix>\n");
         p += n;
     } else {
-        n = sprintf(p, "  match score: %f\n", self->match);
+        n = sprintf(p, "  match_score: %f\n", self->match);
         p += n;
-        n = sprintf(p, "  mismatch score: %f\n", self->mismatch);
+        n = sprintf(p, "  mismatch_score: %f\n", self->mismatch);
         p += n;
     }
     if (self->target_gap_function) {
 #if PY_MAJOR_VERSION >= 3
-        n = sprintf(p, "  target gap function: %%R\n");
+        n = sprintf(p, "  target_gap_function: %%R\n");
         p += n;
 #else
         char* s;
         PyObject* representation = PyObject_Repr(self->target_gap_function);
         if (!representation) return PyErr_NoMemory();
         s = PyString_AsString(representation);
-        n = sprintf(p, "  target gap function: %s\n", s);
+        n = sprintf(p, "  target_gap_function: %s\n", s);
         p += n;
         Py_DECREF(representation);
 #endif
     }
     else {
-        n = sprintf(p, "  target open gap score: %f\n",
+        n = sprintf(p, "  target_open_gap_score: %f\n",
                        self->target_open_gap_score);
         p += n;
-        n = sprintf(p, "  target extend gap score: %f\n",
+        n = sprintf(p, "  target_extend_gap_score: %f\n",
                        self->target_extend_gap_score);
         p += n;
-        n = sprintf(p, "  target left open gap score: %f\n",
+        n = sprintf(p, "  target_left_open_gap_score: %f\n",
                        self->target_left_open_gap_score);
         p += n;
-        n = sprintf(p, "  target left extend gap score: %f\n",
+        n = sprintf(p, "  target_left_extend_gap_score: %f\n",
                        self->target_left_extend_gap_score);
         p += n;
-        n = sprintf(p, "  target right open gap score: %f\n",
+        n = sprintf(p, "  target_right_open_gap_score: %f\n",
                        self->target_right_open_gap_score);
         p += n;
-        n = sprintf(p, "  target right extend gap score: %f\n",
+        n = sprintf(p, "  target_right_extend_gap_score: %f\n",
                        self->target_right_extend_gap_score);
         p += n;
     }
     if (self->query_gap_function) {
 #if PY_MAJOR_VERSION >= 3
-        n = sprintf(p, "  query gap function: %%R\n");
+        n = sprintf(p, "  query_gap_function: %%R\n");
         p += n;
 #else
         char* s;
         PyObject* representation = PyObject_Repr(self->query_gap_function);
         if (!representation) return PyErr_NoMemory();
         s = PyString_AsString(representation);
-        n = sprintf(p, "  query gap function: %s\n", s);
+        n = sprintf(p, "  query_gap_function: %s\n", s);
         p += n;
         Py_DECREF(representation);
 #endif
     }
     else {
-        n = sprintf(p, "  query open gap score: %f\n",
+        n = sprintf(p, "  query_open_gap_score: %f\n",
                        self->query_open_gap_score);
         p += n;
-        n = sprintf(p, "  query extend gap score: %f\n",
+        n = sprintf(p, "  query_extend_gap_score: %f\n",
                        self->query_extend_gap_score);
         p += n;
-        n = sprintf(p, "  query left open gap score: %f\n",
+        n = sprintf(p, "  query_left_open_gap_score: %f\n",
                        self->query_left_open_gap_score);
         p += n;
-        n = sprintf(p, "  query left extend gap score: %f\n",
+        n = sprintf(p, "  query_left_extend_gap_score: %f\n",
                        self->query_left_extend_gap_score);
         p += n;
-        n = sprintf(p, "  query right open gap score: %f\n",
+        n = sprintf(p, "  query_right_open_gap_score: %f\n",
                        self->query_right_open_gap_score);
         p += n;
-        n = sprintf(p, "  query right extend gap score: %f\n",
+        n = sprintf(p, "  query_right_extend_gap_score: %f\n",
                        self->query_right_extend_gap_score);
         p += n;
     }
@@ -1970,10 +1970,10 @@ Aligner_set_mode(Aligner* self, PyObject* value, void* closure)
     return -1;
 }
 
-static char Aligner_match__doc__[] = "match score";
+static char Aligner_match_score__doc__[] = "match score";
 
 static PyObject*
-Aligner_get_match(Aligner* self, void* closure)
+Aligner_get_match_score(Aligner* self, void* closure)
 {   if (self->letters) {
         PyErr_SetString(PyExc_ValueError, "using a substitution matrix");
         return NULL;
@@ -1982,7 +1982,7 @@ Aligner_get_match(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_match(Aligner* self, PyObject* value, void* closure)
+Aligner_set_match_score(Aligner* self, PyObject* value, void* closure)
 {   int i;
     const int n = 26;
     const double match = PyFloat_AsDouble(value);
@@ -2001,10 +2001,10 @@ Aligner_set_match(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_mismatch__doc__[] = "mismatch score";
+static char Aligner_mismatch_score__doc__[] = "mismatch score";
 
 static PyObject*
-Aligner_get_mismatch(Aligner* self, void* closure)
+Aligner_get_mismatch_score(Aligner* self, void* closure)
 {   if (self->letters) {
         PyErr_SetString(PyExc_ValueError, "using a substitution matrix");
         return NULL;
@@ -2013,7 +2013,7 @@ Aligner_get_mismatch(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_mismatch(Aligner* self, PyObject* value, void* closure)
+Aligner_set_mismatch_score(Aligner* self, PyObject* value, void* closure)
 {   int i, j;
     const int n = 26;
     const double mismatch = PyFloat_AsDouble(value);
@@ -3811,14 +3811,22 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_mode,
         (setter)Aligner_set_mode,
         Aligner_mode__doc__, NULL},
-    {"match",
-        (getter)Aligner_get_match,
-        (setter)Aligner_set_match,
-        Aligner_match__doc__, NULL},
-    {"mismatch",
-        (getter)Aligner_get_mismatch,
-        (setter)Aligner_set_mismatch,
-        Aligner_mismatch__doc__, NULL},
+    {"match_score",
+        (getter)Aligner_get_match_score,
+        (setter)Aligner_set_match_score,
+        Aligner_match_score__doc__, NULL},
+    {"mismatch_score",
+        (getter)Aligner_get_mismatch_score,
+        (setter)Aligner_set_mismatch_score,
+        Aligner_mismatch_score__doc__, NULL},
+    {"match", /* synonym for match_score */
+        (getter)Aligner_get_match_score,
+        (setter)Aligner_set_match_score,
+        Aligner_match_score__doc__, NULL},
+    {"mismatch", /* synonym for mismatch_score */
+        (getter)Aligner_get_mismatch_score,
+        (setter)Aligner_set_mismatch_score,
+        Aligner_mismatch_score__doc__, NULL},
     {"substitution_matrix",
         (getter)Aligner_get_substitution_matrix,
         (setter)Aligner_set_substitution_matrix,

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1668,20 +1668,20 @@ for the pairwise alignments. To see an overview of the values for all parameters
 \begin{verbatim}
 >>> print(aligner)
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: 0.000000
-  target extend gap score: 0.000000
-  target left open gap score: 0.000000
-  target left extend gap score: 0.000000
-  target right open gap score: 0.000000
-  target right extend gap score: 0.000000
-  query open gap score: 0.000000
-  query extend gap score: 0.000000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: 0.000000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: 0.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: 0.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: 0.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: 0.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: 0.000000
+  query_right_extend_gap_score: 0.000000
   mode: local
 <BLANKLINE>
 \end{verbatim}
@@ -1716,14 +1716,14 @@ object:
 \begin{verbatim}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
->>> aligner.match
+>>> aligner.match_score
 1.0
->>> aligner.mismatch
+>>> aligner.mismatch_score
 0.0
 >>> score = aligner.score("AAA","AAC")
 >>> print(score)
 2.0
->>> aligner.match = 2.0
+>>> aligner.match_score = 2.0
 >>> score = aligner.score("AAA","AAC")
 >>> print(score)
 4.0
@@ -1736,9 +1736,9 @@ Alternatively, you can specify a substitution matrix as follows:
 >>> aligner.substitution_matrix = matrix
 \end{verbatim}
 
-The attributes \verb+aligner.match+ and \verb+aligner.mismatch+ are ignored
-if \verb+aligner.substitution_matrix+ is specified. Likewise, after specifying
-\verb+aligner.match+ or \verb+aligner.mismatch+,
+The attributes \verb+aligner.match_score+ and \verb+aligner.mismatch_score+ are
+ignored if \verb+aligner.substitution_matrix+ is specified. Likewise, after
+specifying \verb+aligner.match_score+ or \verb+aligner.mismatch_score+,
 \verb+aligner.substitution_matrix+  will be ignored.
 
 Note that \verb+aligner.substitution_matrix+ will return a copy of the
@@ -1792,22 +1792,22 @@ These attributes allow for different gap scores for internal gaps and on either 
 A & - &  query left open gap score \\
 C & - &  query left extend gap score \\
 C & - &  query left extend gap score \\
-G & G &  match \\
-G & T &  mismatch \\
+G & G &  match score \\
+G & T &  mismatch score \\
 G & - &  query internal open gap score \\
 A & - &  query internal extend gap score \\
 A & - &  query internal extend gap score \\
-T & T &  match \\
-A & A &  match \\
+T & T &  match score \\
+A & A &  match score \\
 G & - &  query internal open gap score \\
-C & C &  match \\
+C & C &  match score \\
 - & C &  target internal open gap score \\
 - & C &  target internal extend gap score \\
-C & C &  match \\
-T & G &  mismatch \\
-C & C &  match \\
+C & C &  match score \\
+T & G &  mismatch score \\
+C & C &  match score \\
 - & C &  target internal open gap score \\
-A & A &  match \\
+A & A &  match score \\
 - & T &  target right open gap score \\
 - & A &  target right extend gap score \\
 - & A &  target right extend gap score
@@ -2060,7 +2060,7 @@ G-A-T
 Note that different alignments may have the same subsequences aligned to each other. In particular, this may occur if alignments differ from each other in terms of their gap placement only:
 %cont-doctest
 \begin{verbatim}
->>> aligner.mismatch = -10
+>>> aligner.mismatch_score = -10
 >>> alignments = aligner.align("AAACAAA", "AAAGAAA")
 >>> len(alignments)
 2

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -35,69 +35,69 @@ class TestAlignerProperties(unittest.TestCase):
 
     def test_aligner_property_match_mismatch(self):
         aligner = Align.PairwiseAligner()
-        aligner.match = 3.0
-        self.assertAlmostEqual(aligner.match, 3.0)
-        aligner.mismatch = -2.0
-        self.assertAlmostEqual(aligner.mismatch, -2.0)
+        aligner.match_score = 3.0
+        self.assertAlmostEqual(aligner.match_score, 3.0)
+        aligner.mismatch_score = -2.0
+        self.assertAlmostEqual(aligner.mismatch_score, -2.0)
         with self.assertRaises(ValueError):
-            aligner.match = 'not a number'
+            aligner.match_score = 'not a number'
         with self.assertRaises(ValueError):
-            aligner.mismatch = 'not a number'
+            aligner.mismatch_score = 'not a number'
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 3.000000
-  mismatch score: -2.000000
-  target open gap score: 0.000000
-  target extend gap score: 0.000000
-  target left open gap score: 0.000000
-  target left extend gap score: 0.000000
-  target right open gap score: 0.000000
-  target right extend gap score: 0.000000
-  query open gap score: 0.000000
-  query extend gap score: 0.000000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 3.000000
+  mismatch_score: -2.000000
+  target_open_gap_score: 0.000000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: 0.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: 0.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: 0.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: 0.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: 0.000000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
 
     def test_aligner_property_gapscores(self):
         aligner = Align.PairwiseAligner()
         open_score, extend_score = (-5, -1)
-        aligner.target_gap_open = open_score
-        aligner.target_gap_extend = extend_score
-        self.assertAlmostEqual(aligner.target_gap_open, open_score)
-        self.assertAlmostEqual(aligner.target_gap_extend, extend_score)
+        aligner.target_open_gap_score = open_score
+        aligner.target_extend_gap_score = extend_score
+        self.assertAlmostEqual(aligner.target_open_gap_score, open_score)
+        self.assertAlmostEqual(aligner.target_extend_gap_score, extend_score)
         open_score, extend_score = (-6, -7)
         aligner.query_open_gap_score = open_score
         aligner.query_extend_gap_score = extend_score
         self.assertAlmostEqual(aligner.query_open_gap_score, open_score)
         self.assertAlmostEqual(aligner.query_extend_gap_score, extend_score)
         open_score, extend_score = (-3, -9)
-        aligner.target_end_open = open_score
-        aligner.target_end_extend = extend_score
-        self.assertAlmostEqual(aligner.target_end_open, open_score)
-        self.assertAlmostEqual(aligner.target_end_extend, extend_score)
+        aligner.target_end_open_gap_score = open_score
+        aligner.target_end_extend_gap_score = extend_score
+        self.assertAlmostEqual(aligner.target_end_open_gap_score, open_score)
+        self.assertAlmostEqual(aligner.target_end_extend_gap_score, extend_score)
         open_score, extend_score = (-1, -2)
         aligner.query_end_open_gap_score = open_score
         aligner.query_end_extend_gap_score = extend_score
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: 0.000000
-  target extend gap score: 0.000000
-  target left open gap score: 0.000000
-  target left extend gap score: 0.000000
-  target right open gap score: 0.000000
-  target right extend gap score: 0.000000
-  query open gap score: -6.000000
-  query extend gap score: -7.000000
-  query left open gap score: -1.000000
-  query left extend gap score: -2.000000
-  query right open gap score: -1.000000
-  query right extend gap score: -2.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -5.000000
+  target_extend_gap_score: -1.000000
+  target_left_open_gap_score: -3.000000
+  target_left_extend_gap_score: -9.000000
+  target_right_open_gap_score: -3.000000
+  target_right_extend_gap_score: -9.000000
+  query_open_gap_score: -6.000000
+  query_extend_gap_score: -7.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: -2.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: -2.000000
   mode: global
 """)
         self.assertAlmostEqual(aligner.query_end_open_gap_score, open_score)
@@ -136,20 +136,20 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(aligner.query_right_extend_gap_score, score)
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -3.000000
-  target extend gap score: -3.000000
-  target left open gap score: -4.000000
-  target left extend gap score: -4.000000
-  target right open gap score: -4.000000
-  target right extend gap score: -4.000000
-  query open gap score: -2.000000
-  query extend gap score: -2.000000
-  query left open gap score: -5.000000
-  query left extend gap score: -5.000000
-  query right open gap score: -5.000000
-  query right extend gap score: -5.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -3.000000
+  target_extend_gap_score: -3.000000
+  target_left_open_gap_score: -4.000000
+  target_left_extend_gap_score: -4.000000
+  target_right_open_gap_score: -4.000000
+  target_right_extend_gap_score: -4.000000
+  query_open_gap_score: -2.000000
+  query_extend_gap_score: -2.000000
+  query_left_open_gap_score: -5.000000
+  query_left_extend_gap_score: -5.000000
+  query_right_open_gap_score: -5.000000
+  query_right_extend_gap_score: -5.000000
   mode: global
 """)
         with self.assertRaises(ValueError):
@@ -161,6 +161,13 @@ Pairwise sequence aligner with parameters
         with self.assertRaises(TypeError):
             aligner.query_end_gap_score = 'wrong'
 
+    def test_aligner_nonexisting_property(self):
+        aligner = Align.PairwiseAligner()
+        with self.assertRaises(AttributeError):
+            aligner.no_such_property
+        with self.assertRaises(AttributeError):
+            aligner.no_such_property = 1
+
 
 class TestPairwiseGlobal(unittest.TestCase):
 
@@ -171,20 +178,20 @@ class TestPairwiseGlobal(unittest.TestCase):
         aligner.mode = 'global'
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: 0.000000
-  target extend gap score: 0.000000
-  target left open gap score: 0.000000
-  target left extend gap score: 0.000000
-  target right open gap score: 0.000000
-  target right extend gap score: 0.000000
-  query open gap score: 0.000000
-  query extend gap score: 0.000000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: 0.000000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: 0.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: 0.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: 0.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: 0.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: 0.000000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
         self.assertEqual(aligner.algorithm, "Needleman-Wunsch")
@@ -212,27 +219,27 @@ G-A-T
     def test_align_affine1_score(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.match = 0
-        aligner.mismatch = -1
+        aligner.match_score = 0
+        aligner.mismatch_score = -1
         aligner.open_gap_score = -5
         aligner.extend_gap_score = -1
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 0.000000
-  mismatch score: -1.000000
-  target open gap score: -5.000000
-  target extend gap score: -1.000000
-  target left open gap score: -5.000000
-  target left extend gap score: -1.000000
-  target right open gap score: -5.000000
-  target right extend gap score: -1.000000
-  query open gap score: -5.000000
-  query extend gap score: -1.000000
-  query left open gap score: -5.000000
-  query left extend gap score: -1.000000
-  query right open gap score: -5.000000
-  query right extend gap score: -1.000000
+  match_score: 0.000000
+  mismatch_score: -1.000000
+  target_open_gap_score: -5.000000
+  target_extend_gap_score: -1.000000
+  target_left_open_gap_score: -5.000000
+  target_left_extend_gap_score: -1.000000
+  target_right_open_gap_score: -5.000000
+  target_right_extend_gap_score: -1.000000
+  query_open_gap_score: -5.000000
+  query_extend_gap_score: -1.000000
+  query_left_open_gap_score: -5.000000
+  query_left_extend_gap_score: -1.000000
+  query_right_open_gap_score: -5.000000
+  query_right_extend_gap_score: -1.000000
   mode: global
 """)
         score = aligner.score("CC", "ACCT")
@@ -248,20 +255,20 @@ class TestPairwiseLocal(unittest.TestCase):
         self.assertEqual(aligner.algorithm, 'Smith-Waterman')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.100000
-  target extend gap score: -0.100000
-  target left open gap score: -0.100000
-  target left extend gap score: -0.100000
-  target right open gap score: -0.100000
-  target right extend gap score: -0.100000
-  query open gap score: -0.100000
-  query extend gap score: -0.100000
-  query left open gap score: -0.100000
-  query left extend gap score: -0.100000
-  query right open gap score: -0.100000
-  query right extend gap score: -0.100000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.100000
+  target_extend_gap_score: -0.100000
+  target_left_open_gap_score: -0.100000
+  target_left_extend_gap_score: -0.100000
+  target_right_open_gap_score: -0.100000
+  target_right_extend_gap_score: -0.100000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: -0.100000
   mode: local
 """)
         score = aligner.score("AxBx", "zABz")
@@ -285,20 +292,20 @@ zA-Bz
         self.assertEqual(aligner.algorithm, 'Gotoh local alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.100000
-  target extend gap score: 0.000000
-  target left open gap score: -0.100000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.100000
-  target right extend gap score: 0.000000
-  query open gap score: -0.100000
-  query extend gap score: 0.000000
-  query left open gap score: -0.100000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.100000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.100000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.100000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.100000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """)
         score = aligner.score("AxBx", "zABz")
@@ -320,27 +327,27 @@ class TestPairwiseOpenPenalty(unittest.TestCase):
     def test_match_score_open_penalty1(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.match = 2
-        aligner.mismatch = -1
+        aligner.match_score = 2
+        aligner.mismatch_score = -1
         aligner.open_gap_score = -0.1
         aligner.extend_gap_score = 0.0
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 2.000000
-  mismatch score: -1.000000
-  target open gap score: -0.100000
-  target extend gap score: 0.000000
-  target left open gap score: -0.100000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.100000
-  target right extend gap score: 0.000000
-  query open gap score: -0.100000
-  query extend gap score: 0.000000
-  query left open gap score: -0.100000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.100000
-  query right extend gap score: 0.000000
+  match_score: 2.000000
+  mismatch_score: -1.000000
+  target_open_gap_score: -0.100000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.100000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.100000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
         seq1 = "AA"
@@ -369,27 +376,27 @@ A-
     def test_match_score_open_penalty2(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.match = 1.5
-        aligner.mismatch = 0.0
+        aligner.match_score = 1.5
+        aligner.mismatch_score = 0.0
         aligner.open_gap_score = -0.1
         aligner.extend_gap_score = 0.0
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.500000
-  mismatch score: 0.000000
-  target open gap score: -0.100000
-  target extend gap score: 0.000000
-  target left open gap score: -0.100000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.100000
-  target right extend gap score: 0.000000
-  query open gap score: -0.100000
-  query extend gap score: 0.000000
-  query left open gap score: -0.100000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.100000
-  query right extend gap score: 0.000000
+  match_score: 1.500000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.100000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.100000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.100000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
         seq1 = "GAA"
@@ -423,20 +430,20 @@ GA-
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: 0.000000
-  target extend gap score: 0.000000
-  target left open gap score: 0.000000
-  target left extend gap score: 0.000000
-  target right open gap score: 0.000000
-  target right extend gap score: 0.000000
-  query open gap score: -0.100000
-  query extend gap score: 0.000000
-  query left open gap score: -0.100000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.100000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: 0.000000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: 0.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: 0.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
         seq1 = "GAACT"
@@ -457,26 +464,26 @@ GA--T
     def test_match_score_open_penalty4(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.mismatch = -2.0
+        aligner.mismatch_score = -2.0
         aligner.open_gap_score = -0.1
         aligner.extend_gap_score = 0.0
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -2.000000
-  target open gap score: -0.100000
-  target extend gap score: 0.000000
-  target left open gap score: -0.100000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.100000
-  target right extend gap score: 0.000000
-  query open gap score: -0.100000
-  query extend gap score: 0.000000
-  query left open gap score: -0.100000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.100000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: -2.000000
+  target_open_gap_score: -0.100000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.100000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.100000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
         seq1 = "GCT"
@@ -513,20 +520,20 @@ class TestPairwiseExtendPenalty(unittest.TestCase):
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.200000
-  target extend gap score: -0.500000
-  target left open gap score: -0.200000
-  target left extend gap score: -0.500000
-  target right open gap score: -0.200000
-  target right extend gap score: -0.500000
-  query open gap score: -0.200000
-  query extend gap score: -0.500000
-  query left open gap score: -0.200000
-  query left extend gap score: -0.500000
-  query right open gap score: -0.200000
-  query right extend gap score: -0.500000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.200000
+  target_extend_gap_score: -0.500000
+  target_left_open_gap_score: -0.200000
+  target_left_extend_gap_score: -0.500000
+  target_right_open_gap_score: -0.200000
+  target_right_extend_gap_score: -0.500000
+  query_open_gap_score: -0.200000
+  query_extend_gap_score: -0.500000
+  query_left_open_gap_score: -0.200000
+  query_left_extend_gap_score: -0.500000
+  query_right_open_gap_score: -0.200000
+  query_right_extend_gap_score: -0.500000
   mode: global
 """)
         seq1 = "GACT"
@@ -552,20 +559,20 @@ G--T
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.200000
-  target extend gap score: -1.500000
-  target left open gap score: -0.200000
-  target left extend gap score: -1.500000
-  target right open gap score: -0.200000
-  target right extend gap score: -1.500000
-  query open gap score: -0.200000
-  query extend gap score: -1.500000
-  query left open gap score: -0.200000
-  query left extend gap score: -1.500000
-  query right open gap score: -0.200000
-  query right extend gap score: -1.500000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.200000
+  target_extend_gap_score: -1.500000
+  target_left_open_gap_score: -0.200000
+  target_left_extend_gap_score: -1.500000
+  target_right_open_gap_score: -0.200000
+  target_right_extend_gap_score: -1.500000
+  query_open_gap_score: -0.200000
+  query_extend_gap_score: -1.500000
+  query_left_open_gap_score: -0.200000
+  query_left_extend_gap_score: -1.500000
+  query_right_open_gap_score: -0.200000
+  query_right_extend_gap_score: -1.500000
   mode: global
 """)
         seq1 = "GACT"
@@ -602,20 +609,20 @@ class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -1.700000
-  target extend gap score: -1.500000
-  target left open gap score: -1.700000
-  target left extend gap score: -1.500000
-  target right open gap score: -1.700000
-  target right extend gap score: -1.500000
-  query open gap score: -1.700000
-  query extend gap score: -1.500000
-  query left open gap score: -1.700000
-  query left extend gap score: -1.500000
-  query right open gap score: -1.700000
-  query right extend gap score: -1.500000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -1.700000
+  target_extend_gap_score: -1.500000
+  target_left_open_gap_score: -1.700000
+  target_left_extend_gap_score: -1.500000
+  target_right_open_gap_score: -1.700000
+  target_right_extend_gap_score: -1.500000
+  query_open_gap_score: -1.700000
+  query_extend_gap_score: -1.500000
+  query_left_open_gap_score: -1.700000
+  query_left_extend_gap_score: -1.500000
+  query_right_open_gap_score: -1.700000
+  query_right_extend_gap_score: -1.500000
   mode: global
 """)
         seq1 = "GACT"
@@ -646,20 +653,20 @@ class TestPairwisePenalizeEndgaps(unittest.TestCase):
         aligner.query_end_gap_score = end_score
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.200000
-  target extend gap score: -0.800000
-  target left open gap score: 0.000000
-  target left extend gap score: 0.000000
-  target right open gap score: 0.000000
-  target right extend gap score: 0.000000
-  query open gap score: -0.200000
-  query extend gap score: -0.800000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.200000
+  target_extend_gap_score: -0.800000
+  target_left_open_gap_score: 0.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: 0.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.200000
+  query_extend_gap_score: -0.800000
+  query_left_open_gap_score: 0.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: 0.000000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """)
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
@@ -715,20 +722,20 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
         self.assertEqual(aligner.algorithm, 'Gotoh local alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.300000
-  target extend gap score: 0.000000
-  target left open gap score: -0.300000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.300000
-  target right extend gap score: 0.000000
-  query open gap score: -0.800000
-  query extend gap score: 0.000000
-  query left open gap score: -0.800000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.800000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.300000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.300000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.300000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.800000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.800000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.800000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """)
         score = aligner.score(seq1, seq2)
@@ -762,20 +769,20 @@ GTCT
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.300000
-  target extend gap score: 0.000000
-  target left open gap score: -0.300000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.300000
-  target right extend gap score: 0.000000
-  query open gap score: -0.200000
-  query extend gap score: 0.000000
-  query left open gap score: -0.200000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.200000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.300000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.300000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.300000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.200000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.200000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.200000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """)
         seq1 = "GAT"
@@ -812,20 +819,20 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.100000
-  target extend gap score: 0.000000
-  target left open gap score: -0.100000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.100000
-  target right extend gap score: 0.000000
-  query open gap score: -0.100000
-  query extend gap score: -0.100000
-  query left open gap score: -0.100000
-  query left extend gap score: -0.100000
-  query right open gap score: -0.100000
-  query right extend gap score: -0.100000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.100000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.100000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.100000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.100000
+  query_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.100000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.100000
+  query_right_extend_gap_score: -0.100000
   mode: local
 """)
         score = aligner.score(seq1, seq2)
@@ -904,19 +911,19 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match/mismatch score: <substitution matrix>
-  target open gap score: -0.500000
-  target extend gap score: 0.000000
-  target left open gap score: -0.500000
-  target left extend gap score: 0.000000
-  target right open gap score: -0.500000
-  target right extend gap score: 0.000000
-  query open gap score: -0.500000
-  query extend gap score: 0.000000
-  query left open gap score: -0.500000
-  query left extend gap score: 0.000000
-  query right open gap score: -0.500000
-  query right extend gap score: 0.000000
+  match/mismatch_score: <substitution matrix>
+  target_open_gap_score: -0.500000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.500000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.500000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -0.500000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.500000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.500000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """)
         score = aligner.score(seq1, seq2)
@@ -950,19 +957,19 @@ AT-T
         aligner.extend_gap_score = 0.0
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match/mismatch score: <substitution matrix>
-  target open gap score: -1.000000
-  target extend gap score: 0.000000
-  target left open gap score: -1.000000
-  target left extend gap score: 0.000000
-  target right open gap score: -1.000000
-  target right extend gap score: 0.000000
-  query open gap score: -1.000000
-  query extend gap score: 0.000000
-  query left open gap score: -1.000000
-  query left extend gap score: 0.000000
-  query right open gap score: -1.000000
-  query right extend gap score: 0.000000
+  match/mismatch_score: <substitution matrix>
+  target_open_gap_score: -1.000000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -1.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -1.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -1.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """)
         score = aligner.score(seq1, seq2)
@@ -988,19 +995,19 @@ ATT.
         aligner.extend_gap_score = 0.0
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match/mismatch score: <substitution matrix>
-  target open gap score: -1.000000
-  target extend gap score: 0.000000
-  target left open gap score: -1.000000
-  target left extend gap score: 0.000000
-  target right open gap score: -1.000000
-  target right extend gap score: 0.000000
-  query open gap score: -1.000000
-  query extend gap score: 0.000000
-  query left open gap score: -1.000000
-  query left extend gap score: 0.000000
-  query right open gap score: -1.000000
-  query right extend gap score: 0.000000
+  match/mismatch_score: <substitution matrix>
+  target_open_gap_score: -1.000000
+  target_extend_gap_score: 0.000000
+  target_left_open_gap_score: -1.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -1.000000
+  target_right_extend_gap_score: 0.000000
+  query_open_gap_score: -1.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """)
         score = aligner.score(seq1, seq2)
@@ -1027,20 +1034,20 @@ class TestPairwiseOneCharacter(unittest.TestCase):
         self.assertEqual(aligner.algorithm, 'Gotoh local alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.300000
-  target extend gap score: -0.100000
-  target left open gap score: -0.300000
-  target left extend gap score: -0.100000
-  target right open gap score: -0.300000
-  target right extend gap score: -0.100000
-  query open gap score: -0.300000
-  query extend gap score: -0.100000
-  query left open gap score: -0.300000
-  query left extend gap score: -0.100000
-  query right open gap score: -0.300000
-  query right extend gap score: -0.100000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.300000
+  target_extend_gap_score: -0.100000
+  target_left_open_gap_score: -0.300000
+  target_left_extend_gap_score: -0.100000
+  target_right_open_gap_score: -0.300000
+  target_right_extend_gap_score: -0.100000
+  query_open_gap_score: -0.300000
+  query_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.300000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.300000
+  query_right_extend_gap_score: -0.100000
   mode: local
 """)
         score = aligner.score("abcde", "c")
@@ -1064,20 +1071,20 @@ abcde
         self.assertEqual(aligner.algorithm, 'Gotoh local alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.300000
-  target extend gap score: -0.100000
-  target left open gap score: -0.300000
-  target left extend gap score: -0.100000
-  target right open gap score: -0.300000
-  target right extend gap score: -0.100000
-  query open gap score: -0.300000
-  query extend gap score: -0.100000
-  query left open gap score: -0.300000
-  query left extend gap score: -0.100000
-  query right open gap score: -0.300000
-  query right extend gap score: -0.100000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.300000
+  target_extend_gap_score: -0.100000
+  target_left_open_gap_score: -0.300000
+  target_left_extend_gap_score: -0.100000
+  target_right_open_gap_score: -0.300000
+  target_right_extend_gap_score: -0.100000
+  query_open_gap_score: -0.300000
+  query_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.300000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.300000
+  query_right_extend_gap_score: -0.100000
   mode: local
 """)
         score = aligner.score("abcce", "c")
@@ -1109,20 +1116,20 @@ abcce
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.300000
-  target extend gap score: -0.100000
-  target left open gap score: -0.300000
-  target left extend gap score: -0.100000
-  target right open gap score: -0.300000
-  target right extend gap score: -0.100000
-  query open gap score: -0.300000
-  query extend gap score: -0.100000
-  query left open gap score: -0.300000
-  query left extend gap score: -0.100000
-  query right open gap score: -0.300000
-  query right extend gap score: -0.100000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.300000
+  target_extend_gap_score: -0.100000
+  target_left_open_gap_score: -0.300000
+  target_left_extend_gap_score: -0.100000
+  target_right_open_gap_score: -0.300000
+  target_right_extend_gap_score: -0.100000
+  query_open_gap_score: -0.300000
+  query_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.300000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.300000
+  query_right_extend_gap_score: -0.100000
   mode: global
 """)
         seq1 = "abcde"
@@ -1148,20 +1155,20 @@ abcde
         self.assertEqual(aligner.algorithm, 'Gotoh global alignment algorithm')
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: 0.000000
-  target open gap score: -0.300000
-  target extend gap score: -0.100000
-  target left open gap score: -0.300000
-  target left extend gap score: -0.100000
-  target right open gap score: -0.300000
-  target right extend gap score: -0.100000
-  query open gap score: -0.300000
-  query extend gap score: -0.100000
-  query left open gap score: -0.300000
-  query left extend gap score: -0.100000
-  query right open gap score: -0.300000
-  query right extend gap score: -0.100000
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_open_gap_score: -0.300000
+  target_extend_gap_score: -0.100000
+  target_left_open_gap_score: -0.300000
+  target_left_extend_gap_score: -0.100000
+  target_right_open_gap_score: -0.300000
+  target_right_extend_gap_score: -0.100000
+  query_open_gap_score: -0.300000
+  query_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.300000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.300000
+  query_right_extend_gap_score: -0.100000
   mode: global
 """)
         score = aligner.score("abcde", "c")
@@ -1185,16 +1192,16 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.match = 1
-        aligner.mismatch = -1
+        aligner.match_score = 1
+        aligner.mismatch_score = -1
         aligner.target_gap_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -1.000000
-  target gap function: %s
-  query gap function: %s
+  match_score: 1.000000
+  mismatch_score: -1.000000
+  target_gap_function: %s
+  query_gap_function: %s
   mode: global
 """ % (nogaps, specificgaps))
         self.assertEqual(aligner.algorithm,
@@ -1227,16 +1234,16 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.match = 1
-        aligner.mismatch = -1
+        aligner.match_score = 1
+        aligner.mismatch_score = -1
         aligner.target_gap_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -1.000000
-  target gap function: %s
-  query gap function: %s
+  match_score: 1.000000
+  mismatch_score: -1.000000
+  target_gap_function: %s
+  query_gap_function: %s
   mode: global
 """ % (nogaps, specificgaps))
         self.assertEqual(aligner.algorithm,
@@ -1275,22 +1282,22 @@ AAB------------BBAAAACCCCAAAABBBAA--
             return -10
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
-        aligner.match = 1
-        aligner.mismatch = -10
+        aligner.match_score = 1
+        aligner.mismatch_score = -10
         aligner.target_gap_score = gap_score
         self.assertEqual(aligner.algorithm,
                          "Waterman-Smith-Beyer global alignment algorithm")
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -10.000000
-  target gap function: %s
-  query open gap score: 0.000000
-  query extend gap score: 0.000000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: -10.000000
+  target_gap_function: %s
+  query_open_gap_score: 0.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: 0.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: 0.000000
+  query_right_extend_gap_score: 0.000000
   mode: global
 """ % gap_score)
         score = aligner.score(seq1, seq2)
@@ -1308,10 +1315,10 @@ TTG--GAA
         aligner.query_gap_score = gap_score
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -10.000000
-  target gap function: %s
-  query gap function: %s
+  match_score: 1.000000
+  mismatch_score: -10.000000
+  target_gap_function: %s
+  query_gap_function: %s
   mode: global
 """ % (gap_score, gap_score))
         score = aligner.score(seq1, seq2)
@@ -1361,18 +1368,18 @@ TTG--GAA
         specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
         aligner = Align.PairwiseAligner()
         aligner.mode = 'local'
-        aligner.match = 1
-        aligner.mismatch = -1
+        aligner.match_score = 1
+        aligner.mismatch_score = -1
         aligner.target_gap_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(aligner.algorithm,
                          "Waterman-Smith-Beyer local alignment algorithm")
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -1.000000
-  target gap function: %s
-  query gap function: %s
+  match_score: 1.000000
+  mismatch_score: -1.000000
+  target_gap_function: %s
+  query_gap_function: %s
   mode: local
 """ % (nogaps, specificgaps))
         score = aligner.score(seq1, seq2)
@@ -1411,16 +1418,16 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
         aligner = Align.PairwiseAligner()
         aligner.mode = 'local'
-        aligner.match = 1
-        aligner.mismatch = -1
+        aligner.match_score = 1
+        aligner.mismatch_score = -1
         aligner.target_gap_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -1.000000
-  target gap function: %s
-  query gap function: %s
+  match_score: 1.000000
+  mismatch_score: -1.000000
+  target_gap_function: %s
+  query_gap_function: %s
   mode: local
 """ % (nogaps, specificgaps))
         self.assertEqual(aligner.algorithm,
@@ -1459,22 +1466,22 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
             return -10
         aligner = Align.PairwiseAligner()
         aligner.mode = 'local'
-        aligner.match = 1
-        aligner.mismatch = -10
+        aligner.match_score = 1
+        aligner.mismatch_score = -10
         aligner.target_gap_score = gap_score
         self.assertEqual(aligner.algorithm,
                          "Waterman-Smith-Beyer local alignment algorithm")
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -10.000000
-  target gap function: %s
-  query open gap score: 0.000000
-  query extend gap score: 0.000000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: -10.000000
+  target_gap_function: %s
+  query_open_gap_score: 0.000000
+  query_extend_gap_score: 0.000000
+  query_left_open_gap_score: 0.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: 0.000000
+  query_right_extend_gap_score: 0.000000
   mode: local
 """ % gap_score)
         score = aligner.score(seq1, seq2)
@@ -1497,20 +1504,15 @@ TTCCAA
 TTGGAA
 """)
         self.assertEqual(alignment.aligned, (((4, 6),), ((4, 6),)))
-        aligner.query_gap = gap_score
+        aligner.query_gap_score = gap_score
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
-  match score: 1.000000
-  mismatch score: -10.000000
-  target gap function: %s
-  query open gap score: 0.000000
-  query extend gap score: 0.000000
-  query left open gap score: 0.000000
-  query left extend gap score: 0.000000
-  query right open gap score: 0.000000
-  query right extend gap score: 0.000000
+  match_score: 1.000000
+  mismatch_score: -10.000000
+  target_gap_function: %s
+  query_gap_function: %s
   mode: local
-""" % gap_score)
+""" % (gap_score, gap_score))
         alignments = aligner.align(seq1, seq2)
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.0)


### PR DESCRIPTION
…001)

* replaced match/mismatch by match_score/mismatch_score, and disallowing additional attributes

* check that non-existing properties raise an AttributeError

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
